### PR TITLE
Scolastica2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - master
-      - '*.x'
+      - "*.x"
   pull_request:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 permissions:
   contents: read
@@ -44,4 +44,4 @@ jobs:
         run: php artisan key:generate
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: ./vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
         run: php artisan key:generate
 
       - name: Execute tests
-        run: ./vendor/bin/pest
+        run: ./vendor/bin/pest # Changed from vendor/bin/phpunit


### PR DESCRIPTION
Title: Fix CI workflow to use Pest
Description:
Changed `vendor/bin/phpunit` to `./vendor/bin/pest` in `.github/workflows/tests.yml` to fix the `InvalidPestCommand` error. Tested locally with `./vendor/bin/pest`. CI should now pass on PHP 8.2, 8.3, and 8.4.